### PR TITLE
fix: bug fixed for pawn and berolina pawn (direction checks only for vertices in the same decagon)

### DIFF
--- a/src/frontend/src/features/piece/utils.ts
+++ b/src/frontend/src/features/piece/utils.ts
@@ -251,17 +251,23 @@ export function getPossibleMoves(cell: Cell, board: Board): Cell[] {
 
         if (vertex.color === cell.color && vertex.piece === null) {
           if (cell.x === 2) {
-            if ((cell.y + 2) % 50 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 2) % 50 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           } else if (cell.x === 1) {
-            if ((cell.y + 2) % 30 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 2) % 30 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           } else {
-            if ((cell.y + 2) % 10 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 2) % 10 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           }
         }
       }
@@ -292,17 +298,23 @@ export function getPossibleMoves(cell: Cell, board: Board): Cell[] {
 
         if (vertex.color === cell.color && vertex.piece === null) {
           if (cell.x === 2) {
-            if ((cell.y + 48) % 50 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 48) % 50 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           } else if (cell.x === 1) {
-            if ((cell.y + 28) % 30 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 28) % 30 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           } else {
-            if ((cell.y + 8) % 10 !== vertex.y) {
-              possibleMoves.push(vertex)
-            }
+            if (cell.x === vertex.x) {
+              if ((cell.y + 8) % 10 !== vertex.y) {
+                possibleMoves.push(vertex)
+              }
+            } else possibleMoves.push(vertex)
           }
         }
       }
@@ -356,17 +368,23 @@ export function getPossibleMoves(cell: Cell, board: Board): Cell[] {
         if (vertex.color === cell.color && vertex.piece !== null) {
           if (vertex.piece.color !== cell.piece.color) {
             if (cell.x === 2) {
-              if ((cell.y + 2) % 50 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 2) % 50 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             } else if (cell.x === 1) {
-              if ((cell.y + 2) % 30 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 2) % 30 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             } else {
-              if ((cell.y + 2) % 10 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 2) % 10 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             }
           }
         }
@@ -403,17 +421,23 @@ export function getPossibleMoves(cell: Cell, board: Board): Cell[] {
         if (vertex.color === cell.color && vertex.piece !== null) {
           if (vertex.piece.color !== cell.piece.color) {
             if (cell.x === 2) {
-              if ((cell.y + 48) % 50 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 48) % 50 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             } else if (cell.x === 1) {
-              if ((cell.y + 28) % 30 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 28) % 30 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             } else {
-              if ((cell.y + 8) % 10 !== vertex.y) {
-                possibleMoves.push(vertex)
-              }
+              if (cell.x === vertex.x) {
+                if ((cell.y + 8) % 10 !== vertex.y) {
+                  possibleMoves.push(vertex)
+                }
+              } else possibleMoves.push(vertex)
             }
           }
         }


### PR DESCRIPTION
Essentially, the check for whether the pawns and berolina pawns were going in the correct direction depended on modulo arithmetic without checking if the vertex and the selected cell are in the same decagon. This led to an edge case where a vertex in a different decagon than the selected cell was not selected (which it should be; assuming the 'piece' requirements for that cell were met). I fixed this by simply adding an if statement to ensure to only ignore the wrong direction when the selected cell and the vertex are in the same decagon. This applies to both cw and ccw pawn types, and also cw and ccw berolina types.
![1](https://github.com/user-attachments/assets/314c6236-31d6-4d9e-a41b-cf0551844435)
