### PR TITLE
feat: add pawn first move

### DIFF
--- a/src/frontend/src/features/game/reducer.ts
+++ b/src/frontend/src/features/game/reducer.ts
@@ -36,6 +36,8 @@ export function localGameReducer(
 
       const capturedPiece = to.piece
 
+      piece.hasMoved = true
+
       state.boardState.board[to.x][to.y].piece = piece
       state.boardState.board[from.x][from.y].piece = null
 

--- a/src/frontend/src/features/piece/types.ts
+++ b/src/frontend/src/features/piece/types.ts
@@ -18,4 +18,5 @@ export type Piece = {
   color: PieceColor
   value: number
   image: StaticImageData
+  hasMoved: boolean
 }

--- a/src/frontend/src/features/piece/utils.ts
+++ b/src/frontend/src/features/piece/utils.ts
@@ -9,6 +9,7 @@ export function makePiece(type: PieceType, color: PieceColor): Piece {
     color,
     value: PIECE_DATA[type].value,
     image: PIECE_DATA[type].image[color],
+    hasMoved: false,
   }
 }
 
@@ -315,12 +316,6 @@ export function getPossibleMoves(
     }
     case "pawn-cw": {
       // cell.edges.next = ccw direction, cell.edges.prev = cw direction
-      // TODO: implement first Move
-      // if (cell.piece.firstMove) {
-      //   // stuff
-      //   cell.piece.firstMove = false
-      // } else { stuff below
-      // }
 
       if (cell.edges.length === 3) {
         const edge = board[cell.edges[2][0]][cell.edges[2][1]]
@@ -332,6 +327,10 @@ export function getPossibleMoves(
       const edge = board[cell.edges[1][0]][cell.edges[1][1]]
       if (edge.piece === null) {
         possibleMoves.add(edge)
+        if (!cell.piece.hasMoved) {
+          const firstMoveEdge = board[cell.edges[1][0]][cell.edges[1][1] - 1]
+          if (firstMoveEdge.piece === null) possibleMoves.add(firstMoveEdge)
+        }
       }
 
       for (const vertexTuple of cell.vertices) {
@@ -365,12 +364,6 @@ export function getPossibleMoves(
     }
     case "pawn-ccw": {
       // cell.edges.next = ccw direction, cell.edges.prev = cw direction
-      // TODO: implement first Move
-      // if (cell.piece.firstMove) {
-      //   // stuff
-      //   cell.piece.firstMove = false
-      // } else { stuff below
-      // }
 
       if (cell.edges.length === 3) {
         const edge = board[cell.edges[2][0]][cell.edges[2][1]]
@@ -382,6 +375,10 @@ export function getPossibleMoves(
       const edge = board[cell.edges[0][0]][cell.edges[0][1]]
       if (edge.piece === null) {
         possibleMoves.add(edge)
+        if (!cell.piece.hasMoved) {
+          const firstMoveEdge = board[cell.edges[0][0]][cell.edges[0][1] + 1]
+          if (firstMoveEdge.piece === null) possibleMoves.add(firstMoveEdge)
+        }
       }
 
       for (const vertexTuple of cell.vertices) {


### PR DESCRIPTION
In this branch I added a pawn first move feature. To start, I added a `hasMoved` attribute to the `Piece` type. This attribute gets set to `false` as default and only gets set to `true` in the `MOVE_PIECE` action whenever a piece is moved. For a `pawn-cw` and `pawn-ccw`, the `possibleMoves` in the `getPossibleMoves` function is then conditionally changed based off the `hasMoved` attribute.
So for example, in the below picture, the pawn can move 2 spaces forward in its decagon:
![image](https://github.com/user-attachments/assets/e7cf64f1-98c5-46c3-aef6-991435d94e98)
But after it has moved, it can only move 1 space forward in its decagon:
![image](https://github.com/user-attachments/assets/851d4b4a-27e2-4b99-ab50-4c9a6d94ba60)

Quick note: the diagonal movements are still bugged due to the way the new board has its `x` and `y` attributes within the `Cell` type, but that topic is probably for a different PR.