### PR TITLE
fix: modify cell and vertex creation functions to match new board layout

### DIFF
--- a/src/frontend/src/features/board/cell.ts
+++ b/src/frontend/src/features/board/cell.ts
@@ -21,29 +21,38 @@ export function makeCell(x: number, y: number, angle: number): Cell {
 export function setCellEdges({ x, y, edges }: Cell) {
   // saved in the form of [next (ccw), prev (cw), side]
   if (x === 0) {
-    // inner ring
+    // inner ring - only 1 type of cell
+    // type 1 inner edges
     edges.push([x, (y + 1) % 10])
     edges.push([x, (y + 9) % 10])
-    edges.push([x + 1, (3 * (y + 1)) % 10])
+    // type 1 middle edges
+    edges.push([x + 1, (3 * (y + 1)) % 30])
   } else if (x === 1) {
-    // middle ring
+    // middle ring - type 1: y = 3k, type 2: y = 3k + 1, type 3: y = 3k + 2
+    // type 1, 2, or 3 middle edges
     edges.push([x, (y + 1) % 30])
     edges.push([x, (y + 29) % 30])
     if (y % 3 === 0) {
-      edges.push([x - 1, (Math.floor(y / 3) - 1 + 10) % 10])
-    } else if ((y - 2) % 3 === 0) {
-      edges.push([x + 1, Math.floor((5 * y + 5) / 3) % 50])
+      // type 1 inner edges
+      edges.push([x - 1, (y / 3 - 1 + 10) % 10])
+    } else if ((y - 1) % 3 === 0) {
+      // type 2 outer edges
+      edges.push([x + 1, ((5 * y + 1) / 3) % 50])
     } else {
-      edges.push([x + 1, Math.floor((5 * y + 1) / 3) % 50])
+      // type 3 outer edges
+      edges.push([x + 1, ((5 * y + 5) / 3) % 50])
     }
   } else {
-    // outer ring
+    // outer ring - type 1: y = 5k, type 2: y = 5k + 1, type 3: y = 5k + 2, type 4: y = 5k + 3, type 5: y = 5k + 4
+    // type 1, 2, 3, 4, or 5 outer edges
     edges.push([x, (y + 1) % 50])
     edges.push([x, (y + 49) % 50])
     if (y % 5 === 0) {
-      edges.push([x - 1, (Math.floor((3 * y - 5) / 5) + 30) % 30])
+      // type 1 middle edges
+      edges.push([x - 1, ((3 * y - 5) / 5 + 30) % 30])
     } else if ((y - 2) % 5 === 0) {
-      edges.push([x - 1, Math.floor((3 * y - 1) / 5) % 30])
+      // type 3 middle edges
+      edges.push([x - 1, ((3 * y - 1) / 5) % 30])
     }
   }
 }
@@ -71,8 +80,8 @@ export function setCellVertices({ x, y, edges, vertices }: Cell, board: Board) {
         vertices.push([x - 1, (edges[2][1] + i + 10) % 10])
       }
       // type 1 middle cell outer vertices
-      for (const i of [-1, 0, 1]) {
-        vertices.push([x + 1, (Math.floor((5 / 3) * y + 1) + i) % 50])
+      for (const i of [-2, -1, 0]) {
+        vertices.push([x + 1, (board[x][edges[0][1]].edges[2][1] + i) % 50])
       }
     } else {
       // type 2 or 3 middle cell middle vertices


### PR DESCRIPTION
With the new board layout came the bug of each cell's edges and vertices being offset. I've fixed up the `setCellEdges` and `setCellVertices` functions in the `cell.ts` file in the `board` component to match the new layout.

Mian, I know you originally put a lot of work into these functions with the old board layout, so if you think I should change anything, let me know 👍

The `setCellEdges` function is pretty straight forward, but the `setCellVertices` function is quite complex. I've added comments displaying what each block of code does for each cell type in each respective decagon.

Contributes to #48 