### PR TITLE
fix: cell angles for bishop moveset

### DIFF
--- a/src/frontend/src/features/board/utils.ts
+++ b/src/frontend/src/features/board/utils.ts
@@ -15,44 +15,31 @@ export function initializeBoard(): Board {
   for (let ring = 0; ring < rings.length; ring++) {
     const tiles = rings[ring]
     let angle = 0
-    let flipCounter2 = 2
-    let flipCounter4 = 4
+    let flipCounter = 0
 
     // loop through loopRange
     for (let tile = 0; tile < tiles.length; tile++) {
       const cell = makeCell(ring, tile, angle)
       board[ring].push(cell)
 
-      // logic for angle and counters...
+      // logic for angle and counters
+      // inner ring (increment every cell by 36)
       if (ring === 0) {
         angle = (angle + 36) % 360
-      } else if (ring === 1) {
-        if (flipCounter2 === 2) {
-          flipCounter2 = 0
-          angle = (angle + 36) % 360
-        } else {
-          if (flipCounter2 === 0) {
-            angle = (angle - 36 + 360) % 360 // must add 360 so negative angle is not returned
-          } else {
-            angle = (angle + 36) % 360
-          }
-
-          flipCounter2 += 1
-        }
-      } else {
-        if (flipCounter4 === 4) {
-          flipCounter4 = 0
-          angle = (angle + 36) % 360
-        } else {
-          if (flipCounter4 % 2 === 0) {
-            angle = (angle - 36 + 360) % 360 // must add 360 so negative angle is not returned
-          } else {
-            angle = (angle + 36) % 360
-          }
-
-          flipCounter4 += 1
-        }
       }
+      // center ring (pattern is down, up, up)
+      else if (ring === 1) {
+        if (flipCounter % 3 === 0) {
+          angle = (angle - 36 + 360) % 360
+        } else angle = (angle + 36) % 360
+      }
+      // outter ring (pattern is down, up, down, up, up)
+      else {
+        if (flipCounter % 5 === 0 || flipCounter % 5 === 2) {
+          angle = (angle - 36 + 360) % 360
+        } else angle = (angle + 36) % 360
+      }
+      flipCounter += 1
     }
   }
 

--- a/src/frontend/src/features/piece/utils.ts
+++ b/src/frontend/src/features/piece/utils.ts
@@ -111,8 +111,9 @@ export function getPossibleMoves(
                 if (cell.x === 0) {
                   if (
                     attachedVertex.x === 2 &&
-                    (attachedVertex.y + 48) % 5 !== 0 &&
-                    (attachedVertex.y + 47) % 5 !== 0
+                    ((cell.y * 5) % 50 === attachedVertex.y ||
+                      (cell.y * 5 + 4) % 50 === attachedVertex.y ||
+                      (cell.y * 5 + 8) % 50 === attachedVertex.y)
                   ) {
                     possibleMoves.add(attachedVertex)
                     break
@@ -121,8 +122,8 @@ export function getPossibleMoves(
                   // cell.x = 2
                   if (
                     attachedVertex.x === 0 &&
-                    (cell.y + 48) % 5 !== 0 &&
-                    (cell.y + 47) % 5 !== 0
+                    (cell.y + 4) % 5 !== 0 &&
+                    (cell.y + 3) % 5 !== 0
                   ) {
                     possibleMoves.add(attachedVertex)
                     break


### PR DESCRIPTION
This PR is for fixing the bishop moveset which is dependent on the cell angles.
After the adjustment of the cell positionings, the cell angle creation in the `initializeBoard` function and the bishop case in the `getPossibleMoves` function had to be adjusted.
It should be good now. Here are some test cases:
![image](https://github.com/user-attachments/assets/ecdd0b42-63a0-467a-a688-910267636e9d)
![image](https://github.com/user-attachments/assets/5a98573d-91f3-4e2e-825b-e4b9b047ec8a)
![image](https://github.com/user-attachments/assets/7a6eb9f1-39c9-4731-90c5-0c84f031c54e)
![image](https://github.com/user-attachments/assets/d792a69f-011b-4931-ad60-d832a29f2c1f)

If you think there's anything that needs clean up or commenting, go for it! Or let me know and I'll fix it up.