### PR TITLE
feat: add stalemate functionality

### DIFF
--- a/src/frontend/src/features/board/utils.ts
+++ b/src/frontend/src/features/board/utils.ts
@@ -118,8 +118,14 @@ function checkForCheckmate(board: Board, king: Cell) {
   return true
 }
 
-// TODO
-export function checkForStalemate(board: Board): boolean {
-  console.info(board)
-  return false
+export function checkForStalemate(board: Board, color: PieceColor): boolean {
+  for (const ring of board) {
+    for (const cell of ring) {
+      if (cell.piece !== null && cell.piece.color === color) {
+        const possibleMoves = getPossibleMoves(cell, board)
+        if (possibleMoves.size > 0) return false
+      }
+    }
+  }
+  return true
 }

--- a/src/frontend/src/features/game/reducer.ts
+++ b/src/frontend/src/features/game/reducer.ts
@@ -1,4 +1,4 @@
-import { checkForCheckOrMate } from "../board/utils"
+import { checkForCheckOrMate, checkForStalemate } from "../board/utils"
 import { canPromote, getPossibleMoves } from "../piece/utils"
 import type { LocalGameAction, LocalGameState } from "./types"
 import { createNewGameState, getMove } from "./utils"
@@ -50,7 +50,14 @@ export function localGameReducer(
         state.turn === "w" ? "b" : "w"
       )
 
-      const status = isCheckmate ? "checkmate" : "playing"
+      const status = isCheckmate
+        ? "checkmate"
+        : checkForStalemate(
+              state.boardState.board,
+              state.turn === "w" ? "b" : "w"
+            )
+          ? "draw-stalemate"
+          : "playing"
 
       const newMove = getMove(
         state.turn,

--- a/src/frontend/src/features/game/types.ts
+++ b/src/frontend/src/features/game/types.ts
@@ -23,6 +23,7 @@ export type GameStatus =
   | "draw-agreement"
   | "draw-threefold"
   | "draw-fifty-move"
+  | "draw-insufficient"
   | "resignation"
   | "time-expired"
 


### PR DESCRIPTION
This PR is for the implementation of stalemate. For the time being, the most prominent of the give different stalemate types are implemented (where the king has no available moves but is not in check).
Quick Example. In this position, passively moving either rook while remaining in its decagon will cause a statement as the pawns are blocking a check, but there are no available moves (left pawn is CW, right pawn is CCW):
![image](https://github.com/user-attachments/assets/3441b6f5-936a-42ff-b949-85bcd6fd2426)
Thanks to Saad and Mian's Checkmate implementation, the draw screen automatically appears once the status is set to one of the 5 draw types:
![image](https://github.com/user-attachments/assets/961bd5eb-f17c-4b35-9808-12b1264c4a46)
